### PR TITLE
Fix Navbar overflowing at 1024px Laptop

### DIFF
--- a/styles/Navbar.module.css
+++ b/styles/Navbar.module.css
@@ -67,7 +67,7 @@
   font-family: "DM Mono", sans-serif;
 }
 
-@media screen and (max-width: 920px) {
+@media screen and (max-width: 1024px) {
   .connect {
     display: none;
   }


### PR DESCRIPTION
From this

![image](https://user-images.githubusercontent.com/58532267/165379273-ce95f730-6144-46ae-af53-a4d8793980a7.png)

to this 

![image](https://user-images.githubusercontent.com/58532267/165379319-13671d53-fe45-4966-aa6d-b3f640256718.png)

Instead of some custom dimensions we should stick to the standard ones like `1024px`, `768px`